### PR TITLE
Fix highlighting on prime sieve example

### DIFF
--- a/demo/sieve2-s.py
+++ b/demo/sieve2-s.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Iterator
+||from typing import Iterator||
 
 def iter_primes||() -> Iterator[int]||:
      # An iterator of all numbers between 2 and


### PR DESCRIPTION
Added missing highlight to the "Prime number sieve with generators" mypy with static typing example.