### PR TITLE
Build updates for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 site.css
 site.css.map
 *~
+out/static

--- a/build.py
+++ b/build.py
@@ -145,7 +145,7 @@ def main():
         shutil.copy(f, out_dir + '/')
     for d in static_dirs:
         dn = out_dir + '/' + d
-        shutil.rmtree(dn)
+        shutil.rmtree(dn, ignore_errors=True)
         shutil.copytree(d, dn)
 
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+pip install pyyaml
+npm install sass
+python build.py


### PR DESCRIPTION
This PR makes it easy to host mypy-lang.org on [Render](https://render.com) or other CI driven hosts. 

I work at Render, and a sample version is running on https://mypy-lang-ag.onrender.com.

Hosting it on Render as a free [static site](https://render.com/docs/static-sites) has a few benefits:

1. Automatic SSL management, getting rid of the 'Not Secure' Chrome warning. Fixes https://github.com/JukkaL/mypy-website/issues/12

![image](https://user-images.githubusercontent.com/59905/54881551-715deb80-4e0e-11e9-8d90-d241b2d33af8.png)

2. The site is quite fast already but Render hosts it on a global CDN which makes it consistently fast for all users.

3. Render builds and deploys the site automatically on push, obviating `copy-to-server.sh` and allowing repo maintainers to update the site without SSH creds for mypy-lang.org.

Deployment on Render is trivial: 

1. Signup using invite code `anurag`
2. Create a new Web Service and connect the GitHub repo to Render
3. Use the following values during creation:

    Build command: `./scripts/build.sh`

    Publish directory: `out`

4. Add and verify mypy-lang.org as a custom domain (https://render.com/docs/custom-domains)

We'd love to host mypy-lang.org on Render!