### PR TITLE
Github Pages auto-deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+---
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, closed]
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+
+jobs:
+  build:
+    name: "Build mypy-website"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "checkout mypy-website"
+        uses: "actions/checkout@v2"
+      - name: "Install requirements for build"
+        run: sudo apt install -y python3-yaml ruby-sass
+      - name: "Build mypy-website"
+        run: python3 build.py
+      - name: "Check artifacts"
+        run: |
+          ls -la out
+          test -e out/site.css || exit 1
+          test -e out/index.html || exit 2
+      - name: "Upload website artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: out
+          path: out
+          if-no-files-found: error
+  ghpages:
+    name: "Upload to GitHub pages"
+    runs-on: "ubuntu-latest"
+    needs: build
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: out
+          path: out
+      - name: Deploy the mypy website 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.7
+        with:
+          branch: gh-pages
+          folder: out

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Dependencies:
 
-* Python 2
+* Python
 * `pyyaml` (`pip install pyyaml`)
 * `sass` (`sudo gem install sass`)
 
@@ -11,9 +11,3 @@ To build locally:
 python build.py
 ```
 Output is in `out`.
-
-To build and update the website:
-```
-scripts/copy-to-server.sh
-```
-This runs build.py and then copies everything from `out` to `mypy-lang.org`.

--- a/build.py
+++ b/build.py
@@ -1,7 +1,5 @@
 """Build mypy website (html and css).
 
-Use Python 2 to run this.
-
 Needs sass. Use "sudo gem install sass" to install.
 
 NOTES:


### PR DESCRIPTION
This is based on what Christian Heimes and I worked out for Python on WASM: https://github.com/ethanhs/python-wasm/blob/main/.github/workflows/ci.yml

Before merging you will need to:

1. [x] Enable Github actions. Unfortunately, the only way I've found to do this is to go to the actions tab, create an action in the github UI, commit it to a PR, then close that PR (e.g. https://github.com/ethanhs/python-wasm/pull/25)
2. [ ] Enable Github pages https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site#creating-your-site
3. [ ] Check Enforce HTTPS https://docs.github.com/en/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https


After merging and making sure https://jukkal.github.io/mypy-website looks correct you can switch to using the mypy-lang domain https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages

Also it seems that the build script is fine with Python3 so I changed things to reflect that.


Let me know if you have any questions/concerns!